### PR TITLE
[Refactor] Fix PartialOrd clippy warning

### DIFF
--- a/src/timecode.rs
+++ b/src/timecode.rs
@@ -707,7 +707,7 @@ impl Eq for Timecode {}
 
 impl PartialOrd for Timecode {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.seconds.partial_cmp(&other.seconds)
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
To get coverage reports for CI, we need to use the nightly compiler.

However, clippy had a complaint that isn't present on stable. This PR fixes that complaint.